### PR TITLE
Improve typing for decorated function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dogpile_breaker"
-version = "0.1.0"
-description = "Add your description here"
+version = "0.2.0"
+description = "Cache for Asyncio Applications with Anti-Dogpile Effect"
 readme = "README.md"
 authors = [
     { name = "Dmitry P.", email = "wwarne@gmail.com" }

--- a/src/dogpile_breaker/__init__.py
+++ b/src/dogpile_breaker/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from .api import CacheRegion, ShouldCacheFunc, StorageBackend
 from .redis_backend import RedisStorageBackend

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ wheels = [
 
 [[package]]
 name = "dogpile-breaker"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Now mypy will warn you in case you use .call_without_cache or .save_to_cache without needed parameters