### PR TITLE
Propagate exceptions during singleflight request

### DIFF
--- a/src/dogpile_breaker/api.py
+++ b/src/dogpile_breaker/api.py
@@ -200,6 +200,9 @@ class CacheRegion:
                     jitter_func=jitter_func,
                 )
                 herd_leader.set_result(result)
+            except Exception as e:
+                herd_leader.set_exception(e)
+                raise e
             finally:
                 self.awaits.pop(key, None)
         else:


### PR DESCRIPTION
In case herd_leader has broken propagate its Exception to avoid other… coroutines to wait indefinitely